### PR TITLE
check_tests: return integer during short-circuit return path

### DIFF
--- a/pytest_austin/__init__.py
+++ b/pytest_austin/__init__.py
@@ -204,7 +204,7 @@ class PyTestAustin(ThreadedAustin):
             raise RuntimeError("Austin is still running.")
 
         if not self.data:
-            return
+            return 0
 
         # Prepare stats
         for sample in self.data:


### PR DESCRIPTION
### Requirements for Adding, Changing, Fixing or Removing a Feature

### Description of the Change
Returns an integer value from the `check_tests` method during a short-circuit (when no data has been collected).

Without this, an exception can occur when the plugin is used and collects no sample data: an attempt will be made to add the existing `None` return value from the `check_tests` method to the integer `pytest` `session.testsfailed` value.

### Alternate Designs
Not considered.

### Regressions
I believe this should be a safe change.

### Verification Process
Todo:

- [ ] ~~Ensure that unit tests run correctly~~
- [ ] ~~Add test coverage to demonstrate the problem and confirm the fix~~
- [x] Local testing

May resolve #3.